### PR TITLE
I added this check ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ v0.23 + 1
 
 ### Changes or improvements
 
+* Custom merge drivers can now be registered, which allows callers to
+  configure callbacks to honor `merge=driver` configuration in
+  `.gitattributes`.
+
 * Custom filters can now be registered with wildcard attributes, for
   example `filter=*`.  Consumers should examine the attributes parameter
   of the `check` function for details.
@@ -35,7 +39,6 @@ v0.23 + 1
 * `git_fetch_options` and `git_push_options` have gained a `custom_headers`
   field to set the extra HTTP header fields to send.
 
-
 * `git_stream_register_tls()` lets you register a callback to be used
   as the constructor for a TLS stream instead of the libgit2 built-in
   one.
@@ -43,6 +46,10 @@ v0.23 + 1
 ### API removals
 
 ### Breaking API changes
+
+* `git_merge_options` now provides a `default_driver` that can be used
+  to provide the name of a merge driver to be used to handle files changed
+  during a merge.
 
 * The `git_merge_tree_flag_t` is now `git_merge_flag_t`.  Subsequently,
   its members are no longer prefixed with `GIT_MERGE_TREE_FLAG` but are

--- a/include/git2/merge.h
+++ b/include/git2/merge.h
@@ -273,7 +273,16 @@ typedef struct {
 	 */
 	unsigned int recursion_limit;
 
-	/** Flags for handling conflicting content. */
+	/**
+	 * Default merge driver to be used when both sides of a merge have
+	 * changed.  The default is the `text` driver.
+	 */
+	const char *default_driver;
+
+	/**
+	 * Flags for handling conflicting content, to be used with the standard
+	 * (`text`) merge driver.
+	 */
 	git_merge_file_favor_t file_favor;
 
 	/** see `git_merge_file_flag_t` above */

--- a/include/git2/sys/merge.h
+++ b/include/git2/sys/merge.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+#ifndef INCLUDE_sys_git_merge_h__
+#define INCLUDE_sys_git_merge_h__
+
+/**
+ * @file git2/sys/merge.h
+ * @brief Git merge driver backend and plugin routines
+ * @defgroup git_backend Git custom backend APIs
+ * @ingroup Git
+ * @{
+ */
+GIT_BEGIN_DECL
+
+typedef struct git_merge_driver git_merge_driver;
+
+/**
+ * Look up a merge driver by name
+ *
+ * @param name The name of the merge driver
+ * @return Pointer to the merge driver object or NULL if not found
+ */
+GIT_EXTERN(git_merge_driver *) git_merge_driver_lookup(const char *name);
+
+#define GIT_MERGE_DRIVER_TEXT   "text"
+#define GIT_MERGE_DRIVER_BINARY "binary"
+#define GIT_MERGE_DRIVER_UNION  "union"
+
+/**
+ * A merge driver source represents the file to be merged
+ */
+typedef struct git_merge_driver_source git_merge_driver_source;
+
+/** Get the repository that the source data is coming from. */
+GIT_EXTERN(git_repository *) git_merge_driver_source_repo(
+	const git_merge_driver_source *src);
+
+/** Gets the ancestor of the file to merge. */
+GIT_EXTERN(git_index_entry *) git_merge_driver_source_ancestor(
+	const git_merge_driver_source *src);
+
+/** Gets the ours side of the file to merge. */
+GIT_EXTERN(git_index_entry *) git_merge_driver_source_ours(
+	const git_merge_driver_source *src);
+
+/** Gets the theirs side of the file to merge. */
+GIT_EXTERN(git_index_entry *) git_merge_driver_source_theirs(
+	const git_merge_driver_source *src);
+
+/** Gets the merge file options that the merge was invoked with */
+GIT_EXTERN(git_merge_file_options *) git_merge_driver_source_file_options(
+	const git_merge_driver_source *src);
+
+
+/*
+ * struct git_merge_driver
+ *
+ * The merge driver lifecycle:
+ * - initialize - first use of merge driver
+ * - shutdown   - merge driver removed/unregistered from system
+ * - check      - considering using merge driver for file
+ * - apply      - apply merge driver to the file
+ * - cleanup    - done with file
+ */
+
+/**
+ * Initialize callback on merge driver
+ *
+ * Specified as `driver.initialize`, this is an optional callback invoked
+ * before a merge driver is first used.  It will be called once at most.
+ *
+ * If non-NULL, the merge driver's `initialize` callback will be invoked
+ * right before the first use of the driver, so you can defer expensive
+ * initialization operations (in case libgit2 is being used in a way that
+ * doesn't need the merge driver).
+ */
+typedef int (*git_merge_driver_init_fn)(git_merge_driver *self);
+
+/**
+ * Shutdown callback on merge driver
+ *
+ * Specified as `driver.shutdown`, this is an optional callback invoked
+ * when the merge driver is unregistered or when libgit2 is shutting down.
+ * It will be called once at most and should release resources as needed.
+ * This may be called even if the `initialize` callback was not made.
+ *
+ * Typically this function will free the `git_merge_driver` object itself.
+ */
+typedef void (*git_merge_driver_shutdown_fn)(git_merge_driver *self);
+
+/**
+ * Callback to decide if a given conflict can be resolved with this merge
+ * driver.
+ *
+ * Specified as `driver.check`, this is an optional callback that checks
+ * if the given conflict can be resolved with this merge driver.
+ *
+ * It should return 0 if the merge driver should be applied (i.e. success),
+ * `GIT_PASSTHROUGH` if the driver is not available, which is the equivalent
+ * of an unregistered or nonexistent merge driver.  In this case, the default
+ * (`text`) driver will be run.  This is useful if you register a wildcard
+ * merge driver but are not interested in handling the requested file (and
+ * should just fallback).  The driver can also return `GIT_EMERGECONFLICT`
+ * if the driver is not able to produce a merge result, and the file will
+ * remain conflicted.  Any other errors will fail and return to the caller.
+ *
+ * The `name` will be set to the name of the driver as configured in the
+ * attributes.
+ *
+ * The `src` contains the data about the file to be merged.
+ *
+ * The `payload` will be a pointer to a reference payload for the driver.
+ * This will start as NULL, but `check` can assign to this pointer for
+ * later use by the `apply` callback.  Note that the value should be heap
+ * allocated (not stack), so that it doesn't go away before the `apply`
+ * callback can use it.  If a driver allocates and assigns a value to the
+ * `payload`, it will need a `cleanup` callback to free the payload.
+ */
+typedef int (*git_merge_driver_check_fn)(
+	git_merge_driver *self,
+	void **payload,
+	const char *name,
+	const git_merge_driver_source *src);
+
+/**
+ * Callback to actually perform the merge.
+ *
+ * Specified as `driver.apply`, this is the callback that actually does the
+ * merge.  If it can successfully perform a merge, it should populate
+ * `path_out` with a pointer to the filename to accept, `mode_out` with
+ * the resultant mode, and `merged_out` with the buffer of the merged file
+ * and then return 0.  If the driver returns `GIT_PASSTHROUGH`, then the
+ * default merge driver should instead be run.  It can also return
+ * `GIT_EMERGECONFLICT` if the driver is not able to produce a merge result,
+ * and the file will remain conflicted.  Any other errors will fail and
+ * return to the caller.
+ *
+ * The `src` contains the data about the file to be merged.
+ *
+ * The `payload` value will refer to any payload that was set by the
+ * `check` callback.  It may be read from or written to as needed.
+ */
+typedef int (*git_merge_driver_apply_fn)(
+	git_merge_driver *self,
+	void **payload,
+	const char **path_out,
+	uint32_t *mode_out,
+	git_buf *merged_out,
+	const git_merge_driver_source *src);
+
+/**
+ * Callback to clean up after merge has been performed.
+ *
+ * Specified as `driver.cleanup`, this is an optional callback invoked
+ * after the driver has been run.  If the `check` or `apply` callbacks
+ * allocated a `payload` to keep per-source merge driver state, use this
+ * callback to free that payload and release resources as required.
+ */
+typedef void (*git_merge_driver_cleanup_fn)(
+	git_merge_driver *self,
+	void *payload);
+
+/**
+ * Merge driver structure used to register custom merge drivers.
+ *
+ * To associate extra data with a driver, allocate extra data and put the
+ * `git_merge_driver` struct at the start of your data buffer, then cast
+ * the `self` pointer to your larger structure when your callback is invoked.
+ *
+ * `version` should be set to GIT_MERGE_DRIVER_VERSION
+ *
+ * The `initialize`, `shutdown`, `check`, `apply`, and `cleanup`
+ * callbacks are all documented above with the respective function pointer
+ * typedefs.
+ */
+struct git_merge_driver {
+	unsigned int                 version;
+
+	git_merge_driver_init_fn     initialize;
+	git_merge_driver_shutdown_fn shutdown;
+	git_merge_driver_check_fn    check;
+	git_merge_driver_apply_fn    apply;
+	git_merge_driver_cleanup_fn  cleanup;
+};
+
+#define GIT_MERGE_DRIVER_VERSION 1
+
+/**
+ * Register a merge driver under a given name.
+ *
+ * As mentioned elsewhere, the initialize callback will not be invoked
+ * immediately.  It is deferred until the driver is used in some way.
+ *
+ * Currently the merge driver registry is not thread safe, so any
+ * registering or deregistering of merge drivers must be done outside of
+ * any possible usage of the drivers (i.e. during application setup or
+ * shutdown).
+ *
+ * @param name The name of this driver to match an attribute.  Attempting
+ * 			to register with an in-use name will return GIT_EEXISTS.
+ * @param driver The merge driver definition.  This pointer will be stored
+ *			as is by libgit2 so it must be a durable allocation (either
+ *			static or on the heap).
+ * @return 0 on successful registry, error code <0 on failure
+ */
+GIT_EXTERN(int) git_merge_driver_register(
+	const char *name, git_merge_driver *driver);
+
+/**
+ * Remove the merge driver with the given name.
+ *
+ * Attempting to remove the builtin libgit2 merge drivers is not permitted
+ * and will return an error.
+ *
+ * Currently the merge driver registry is not thread safe, so any
+ * registering or deregistering of drivers must be done outside of any
+ * possible usage of the drivers (i.e. during application setup or shutdown).
+ *
+ * @param name The name under which the merge driver was registered
+ * @return 0 on success, error code <0 on failure
+ */
+GIT_EXTERN(int) git_merge_driver_unregister(const char *name);
+
+/** @} */
+GIT_END_DECL
+#endif

--- a/src/merge.c
+++ b/src/merge.c
@@ -918,7 +918,7 @@ static int merge_conflict_resolve_contents(
 		 * favor flag) then let that override the gitattributes.
 		 */
 		driver = &git_merge_driver__normal;
-		data = (void *)file_opts->favor;
+		data = (void **)&file_opts->favor;
 	} else {
 		/* find the merge driver for this file */
 		if ((error = git_merge_driver_for_source(&driver, &data, &source)) < 0)

--- a/src/merge.c
+++ b/src/merge.c
@@ -1900,7 +1900,7 @@ int git_merge__iterators(
 		int resolved = 0;
 
 		/* Check for merge options in .gitattributes */
-		if ((error = lookup_file_favor(&opts.file_favor, repo, conflict->our_entry.path) < 0))
+		if ((error = lookup_file_favor(&file_opts.favor, repo, conflict->our_entry.path) < 0))
 			goto done;
 
 		if ((error = merge_conflict_resolve(

--- a/src/merge.c
+++ b/src/merge.c
@@ -1819,6 +1819,28 @@ static git_iterator *iterator_given_or_empty(git_iterator **empty, git_iterator 
 	return *empty;
 }
 
+static int lookup_file_favor(
+	git_merge_file_favor_t *file_favor,
+	git_repository *repo,
+	const char *path)
+{
+	int error = 0;
+	const char *value = NULL;
+
+	if (path) {
+		if ((error = git_attr_get(&value, repo, 0, path, "merge")) < 0)
+			goto done;
+
+		if (*file_favor == GIT_MERGE_FILE_FAVOR_NORMAL &&
+		    value && strcmp(value, "union") == 0) {
+			*file_favor |= GIT_MERGE_FILE_FAVOR_UNION;
+		}
+	}
+
+done:
+	return error;
+}
+
 int git_merge__iterators(
 	git_index **out,
 	git_repository *repo,
@@ -1876,6 +1898,10 @@ int git_merge__iterators(
 
 	git_vector_foreach(&changes, i, conflict) {
 		int resolved = 0;
+
+		/* Check for merge options in .gitattributes */
+		if ((error = lookup_file_favor(&opts.file_favor, repo, conflict->our_entry.path) < 0))
+			goto done;
 
 		if ((error = merge_conflict_resolve(
 			&resolved, diff_list, conflict, &file_opts)) < 0)
@@ -2084,7 +2110,7 @@ static int iterator_for_annotated_commit(
 	opts.flags = GIT_ITERATOR_DONT_IGNORE_CASE;
 
 	if (commit == NULL) {
-		error = git_iterator_for_nothing(out, &opts); 
+		error = git_iterator_for_nothing(out, &opts);
 	} else if (commit->type == GIT_ANNOTATED_COMMIT_VIRTUAL) {
 		error = git_iterator_for_index(out, commit->index, &opts);
 	} else {
@@ -2428,7 +2454,7 @@ static int write_merge_msg(
 	assert(repo && heads);
 
 	entries = git__calloc(heads_len, sizeof(struct merge_msg_entry));
-	GITERR_CHECK_ALLOC(entries); 
+	GITERR_CHECK_ALLOC(entries);
 
 	if (git_vector_init(&matching, heads_len, NULL) < 0) {
 		git__free(entries);
@@ -2482,7 +2508,7 @@ static int write_merge_msg(
 
 	if (matching.length)
 		sep =',';
-	
+
 	if ((error = merge_msg_entries(&matching, entries, heads_len, msg_entry_is_tag)) < 0 ||
 		(error = merge_msg_write_tags(&file, &matching, sep)) < 0)
 		goto cleanup;

--- a/src/merge.c
+++ b/src/merge.c
@@ -261,7 +261,7 @@ int git_merge_base(git_oid *out, git_repository *repo, const git_oid *one, const
 int git_merge_bases(git_oidarray *out, git_repository *repo, const git_oid *one, const git_oid *two)
 {
 	int error;
-        git_revwalk *walk;
+	git_revwalk *walk;
 	git_commit_list *result, *list;
 	git_array_oid_t array;
 
@@ -925,8 +925,8 @@ static int merge_conflict_resolve_contents(
 			goto done;
 	}
 
-    error = merge_conflict_invoke_driver(&merge_result,
-        driver, data, diff_list, &source);
+	error = merge_conflict_invoke_driver(&merge_result,
+		driver, data, diff_list, &source);
 
 	if (error == GIT_PASSTHROUGH) {
 		data = NULL;
@@ -934,12 +934,12 @@ static int merge_conflict_resolve_contents(
 			&git_merge_driver__text, data, diff_list, &source);
 	}
 
-    if (error < 0) {
-        if (error == GIT_EMERGECONFLICT)
-            error = 0;
+	if (error < 0) {
+		if (error == GIT_EMERGECONFLICT)
+			error = 0;
 
-        goto done;
-    }
+		goto done;
+	}
 
 	git_vector_insert(&diff_list->staged, merge_result);
 	git_vector_insert(&diff_list->resolved, (git_merge_diff *)conflict);
@@ -2200,14 +2200,14 @@ static int merge_annotated_commits(
 	git_iterator *base_iter = NULL, *our_iter = NULL, *their_iter = NULL;
 	int error;
 
-    if ((error = compute_base(&base, repo, ours, theirs, opts,
+	if ((error = compute_base(&base, repo, ours, theirs, opts,
 		recursion_level)) < 0) {
 
-        if (error != GIT_ENOTFOUND)
-            goto done;
+		if (error != GIT_ENOTFOUND)
+			goto done;
 
-        giterr_clear();
-    }
+		giterr_clear();
+	}
 
 	if ((error = iterator_for_annotated_commit(&base_iter, base)) < 0 ||
 		(error = iterator_for_annotated_commit(&our_iter, ours)) < 0 ||

--- a/src/merge.h
+++ b/src/merge.h
@@ -40,6 +40,7 @@ enum {
 
 struct git_merge_driver_source {
 	git_repository *repo;
+	const char *default_driver;
 	const git_merge_file_options *file_opts;
 
 	const git_index_entry *ancestor;

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -28,6 +28,9 @@ typedef struct {
 
 static struct merge_driver_registry *merge_driver_registry = NULL;
 
+static git_merge_file_favor_t merge_favor_normal = GIT_MERGE_FILE_FAVOR_NORMAL;
+static git_merge_file_favor_t merge_favor_union = GIT_MERGE_FILE_FAVOR_UNION;
+
 static int merge_driver_apply(
 	git_merge_driver *self,
 	void **payload,
@@ -37,6 +40,7 @@ static int merge_driver_apply(
 	const git_merge_driver_source *src)
 {
 	git_merge_file_options file_opts = GIT_MERGE_FILE_OPTIONS_INIT;
+	git_merge_file_favor_t *favor = (git_merge_file_favor_t *) *payload;
 	git_merge_file_result result = {0};
 	int error;
 
@@ -45,7 +49,8 @@ static int merge_driver_apply(
 	if (src->file_opts)
 		memcpy(&file_opts, src->file_opts, sizeof(git_merge_file_options));
 
-	file_opts.favor = (git_merge_file_favor_t) *payload;
+	if (favor)
+		file_opts.favor = *favor;
 
 	if ((error = git_merge_file_from_index(&result, src->repo,
 		src->ancestor, src->ours, src->theirs, &file_opts)) < 0)
@@ -87,7 +92,7 @@ static int merge_driver_text_check(
 	GIT_UNUSED(name);
 	GIT_UNUSED(src);
 
-	*payload = (void *)GIT_MERGE_FILE_FAVOR_NORMAL;
+	*payload = &merge_favor_normal;
 	return 0;
 }
 
@@ -101,7 +106,7 @@ static int merge_driver_union_check(
 	GIT_UNUSED(name);
 	GIT_UNUSED(src);
 
-	*payload = (void *)GIT_MERGE_FILE_FAVOR_UNION;
+	*payload = &merge_favor_union;
 	return 0;
 }
 

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -143,20 +143,20 @@ static void merge_driver_registry_shutdown(void)
 {
 	struct merge_driver_registry *reg;
 	git_merge_driver_entry *entry;
-    size_t i;
+	size_t i;
 
-    if ((reg = git__swap(merge_driver_registry, NULL)) == NULL)
-        return;
+	if ((reg = git__swap(merge_driver_registry, NULL)) == NULL)
+		return;
 
-    git_vector_foreach(&reg->drivers, i, entry) {
-        if (entry && entry->driver->shutdown)
-            entry->driver->shutdown(entry->driver);
+	git_vector_foreach(&reg->drivers, i, entry) {
+		if (entry && entry->driver->shutdown)
+			entry->driver->shutdown(entry->driver);
 
-        git__free(entry);
-    }
+		git__free(entry);
+	}
 
-    git_vector_free(&reg->drivers);
-    git__free(reg);
+	git_vector_free(&reg->drivers);
+	git__free(reg);
 }
 
 git_merge_driver git_merge_driver__normal = {
@@ -202,15 +202,15 @@ static int merge_driver_registry_initialize(void)
 	reg = git__calloc(1, sizeof(struct merge_driver_registry));
 	GITERR_CHECK_ALLOC(reg);
 
-    if ((error = git_vector_init(&reg->drivers, 3, merge_driver_entry_cmp)) < 0)
+	if ((error = git_vector_init(&reg->drivers, 3, merge_driver_entry_cmp)) < 0)
 		goto done;
 	
-    reg = git__compare_and_swap(&merge_driver_registry, NULL, reg);
+	reg = git__compare_and_swap(&merge_driver_registry, NULL, reg);
 
-    if (reg != NULL)
-        goto done;
+	if (reg != NULL)
+		goto done;
 
-    git__on_shutdown(merge_driver_registry_shutdown);
+	git__on_shutdown(merge_driver_registry_shutdown);
 
 	if ((error = git_merge_driver_register(
 			merge_driver_name__text, &git_merge_driver__text)) < 0 ||
@@ -294,7 +294,7 @@ git_merge_driver *git_merge_driver_lookup(const char *name)
 	if (error == GIT_ENOTFOUND)
 		return NULL;
 
-    entry = git_vector_get(&merge_driver_registry->drivers, pos);
+	entry = git_vector_get(&merge_driver_registry->drivers, pos);
 
 	if (!entry->initialized) {
 		if (entry->driver->initialize &&
@@ -304,7 +304,7 @@ git_merge_driver *git_merge_driver_lookup(const char *name)
 		entry->initialized = 1;
 	}
 
-    return entry->driver;
+	return entry->driver;
 }
 
 static int merge_driver_name_for_path(

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) the libgit2 contributors. All rights reserved.
+ *
+ * This file is part of libgit2, distributed under the GNU GPL v2 with
+ * a Linking Exception. For full terms see the included COPYING file.
+ */
+
+#include "common.h"
+#include "vector.h"
+#include "global.h"
+#include "merge.h"
+#include "git2/merge.h"
+#include "git2/sys/merge.h"
+
+static const char *merge_driver_name__text = "text";
+static const char *merge_driver_name__union = "union";
+static const char *merge_driver_name__binary = "binary";
+
+struct merge_driver_registry {
+	git_vector drivers;
+};
+
+typedef struct {
+	git_merge_driver *driver;
+	int initialized;
+	char name[GIT_FLEX_ARRAY];
+} git_merge_driver_entry;
+
+static struct merge_driver_registry *merge_driver_registry = NULL;
+
+static int merge_driver_apply(
+	git_merge_driver *self,
+	void **payload,
+	const char **path_out,
+	uint32_t *mode_out,
+	git_buf *merged_out,
+	const git_merge_driver_source *src)
+{
+	git_merge_file_options file_opts = GIT_MERGE_FILE_OPTIONS_INIT;
+	git_merge_file_result result = {0};
+	int error;
+
+	GIT_UNUSED(self);
+
+	if (src->file_opts)
+		memcpy(&file_opts, src->file_opts, sizeof(git_merge_file_options));
+
+	file_opts.favor = (git_merge_file_favor_t) *payload;
+
+	if ((error = git_merge_file_from_index(&result, src->repo,
+		src->ancestor, src->ours, src->theirs, &file_opts)) < 0)
+		goto done;
+
+	if (!result.automergeable &&
+		!(file_opts.flags & GIT_MERGE_FILE_FAVOR__CONFLICTED)) {
+		error = GIT_EMERGECONFLICT;
+		goto done;
+	}
+
+	*path_out = git_merge_file__best_path(
+		src->ancestor ? src->ancestor->path : NULL,
+		src->ours ? src->ours->path : NULL,
+		src->theirs ? src->theirs->path : NULL);
+
+	*mode_out = git_merge_file__best_mode(
+		src->ancestor ? src->ancestor->mode : 0,
+		src->ours ? src->ours->mode : 0,
+		src->theirs ? src->theirs->mode : 0);
+
+	merged_out->ptr = (char *)result.ptr;
+	merged_out->size = result.len;
+	merged_out->asize = result.len;
+	result.ptr = NULL;
+
+done:
+	git_merge_file_result_free(&result);
+	return error;
+}
+
+static int merge_driver_text_check(
+	git_merge_driver *self,
+	void **payload,
+	const char *name,
+	const git_merge_driver_source *src)
+{
+	GIT_UNUSED(self);
+	GIT_UNUSED(name);
+	GIT_UNUSED(src);
+
+	*payload = (void *)GIT_MERGE_FILE_FAVOR_NORMAL;
+	return 0;
+}
+
+static int merge_driver_union_check(
+	git_merge_driver *self,
+	void **payload,
+	const char *name,
+	const git_merge_driver_source *src)
+{
+	GIT_UNUSED(self);
+	GIT_UNUSED(name);
+	GIT_UNUSED(src);
+
+	*payload = (void *)GIT_MERGE_FILE_FAVOR_UNION;
+	return 0;
+}
+
+static int merge_driver_binary_apply(
+	git_merge_driver *self,
+	void **payload,
+	const char **path_out,
+	uint32_t *mode_out,
+	git_buf *merged_out,
+	const git_merge_driver_source *src)
+{
+	GIT_UNUSED(self);
+	GIT_UNUSED(payload);
+	GIT_UNUSED(path_out);
+	GIT_UNUSED(mode_out);
+	GIT_UNUSED(merged_out);
+	GIT_UNUSED(src);
+
+	return GIT_EMERGECONFLICT;
+}
+
+static int merge_driver_entry_cmp(const void *a, const void *b)
+{
+	const git_merge_driver_entry *entry_a = a;
+	const git_merge_driver_entry *entry_b = b;
+
+	return strcmp(entry_a->name, entry_b->name);
+}
+
+static int merge_driver_entry_search(const void *a, const void *b)
+{
+	const char *name_a = a;
+	const git_merge_driver_entry *entry_b = b;
+
+	return strcmp(name_a, entry_b->name);
+}
+
+static void merge_driver_registry_shutdown(void)
+{
+	struct merge_driver_registry *reg;
+	git_merge_driver_entry *entry;
+    size_t i;
+
+    if ((reg = git__swap(merge_driver_registry, NULL)) == NULL)
+        return;
+
+    git_vector_foreach(&reg->drivers, i, entry) {
+        if (entry && entry->driver->shutdown)
+            entry->driver->shutdown(entry->driver);
+
+        git__free(entry);
+    }
+
+    git_vector_free(&reg->drivers);
+    git__free(reg);
+}
+
+git_merge_driver git_merge_driver__normal = {
+	GIT_MERGE_DRIVER_VERSION,
+	NULL,
+	NULL,
+	NULL,
+	merge_driver_apply
+};
+
+git_merge_driver git_merge_driver__text = {
+	GIT_MERGE_DRIVER_VERSION,
+	NULL,
+	NULL,
+	merge_driver_text_check,
+	merge_driver_apply
+};
+
+git_merge_driver git_merge_driver__union = {
+	GIT_MERGE_DRIVER_VERSION,
+	NULL,
+	NULL,
+	merge_driver_union_check,
+	merge_driver_apply
+};
+
+git_merge_driver git_merge_driver__binary = {
+	GIT_MERGE_DRIVER_VERSION,
+	NULL,
+	NULL,
+	NULL,
+	merge_driver_binary_apply
+};
+
+static int merge_driver_registry_initialize(void)
+{
+	struct merge_driver_registry *reg;
+	int error = 0;
+
+	if (merge_driver_registry)
+		return 0;
+
+	reg = git__calloc(1, sizeof(struct merge_driver_registry));
+	GITERR_CHECK_ALLOC(reg);
+
+    if ((error = git_vector_init(&reg->drivers, 3, merge_driver_entry_cmp)) < 0)
+		goto done;
+	
+    reg = git__compare_and_swap(&merge_driver_registry, NULL, reg);
+
+    if (reg != NULL)
+        goto done;
+
+    git__on_shutdown(merge_driver_registry_shutdown);
+
+	if ((error = git_merge_driver_register(
+			merge_driver_name__text, &git_merge_driver__text)) < 0 ||
+		(error = git_merge_driver_register(
+			merge_driver_name__union, &git_merge_driver__union)) < 0 ||
+		(error = git_merge_driver_register(
+			merge_driver_name__binary, &git_merge_driver__binary)) < 0)
+		goto done;
+
+done:
+	if (error < 0)
+		merge_driver_registry_shutdown();
+
+	return error;
+}
+
+int git_merge_driver_register(const char *name, git_merge_driver *driver)
+{
+	git_merge_driver_entry *entry;
+
+	assert(name && driver);
+
+	if (merge_driver_registry_initialize() < 0)
+		return -1;
+
+	entry = git__calloc(1, sizeof(git_merge_driver_entry) + strlen(name) + 1);
+	GITERR_CHECK_ALLOC(entry);
+
+	strcpy(entry->name, name);
+	entry->driver = driver;
+
+	return git_vector_insert_sorted(
+		&merge_driver_registry->drivers, entry, NULL);
+}
+
+int git_merge_driver_unregister(const char *name)
+{
+	git_merge_driver_entry *entry;
+	size_t pos;
+	int error;
+
+	if ((error = git_vector_search2(&pos, &merge_driver_registry->drivers,
+		merge_driver_entry_search, name)) < 0)
+		return error;
+
+	entry = git_vector_get(&merge_driver_registry->drivers, pos);
+	git_vector_remove(&merge_driver_registry->drivers, pos);
+
+	if (entry->initialized && entry->driver->shutdown) {
+		entry->driver->shutdown(entry->driver);
+		entry->initialized = false;
+	}
+
+	git__free(entry);
+
+	return 0;
+}
+
+git_merge_driver *git_merge_driver_lookup(const char *name)
+{
+	git_merge_driver_entry *entry;
+	size_t pos;
+	int error;
+
+	/* If we've decided the merge driver to use internally - and not
+	 * based on user configuration (in merge_driver_name_for_path)
+	 * then we can use a hardcoded name instead of looking it up in
+	 * the vector.
+	 */
+	if (name == merge_driver_name__text)
+		return &git_merge_driver__text;
+	else if (name == merge_driver_name__binary)
+		return &git_merge_driver__binary;
+
+	if (merge_driver_registry_initialize() < 0)
+		return NULL;
+
+	error = git_vector_search2(&pos, &merge_driver_registry->drivers,
+		merge_driver_entry_search, name);
+
+	if (error == GIT_ENOTFOUND)
+		return NULL;
+
+    entry = git_vector_get(&merge_driver_registry->drivers, pos);
+
+	if (!entry->initialized) {
+		if (entry->driver->initialize &&
+			(error = entry->driver->initialize(entry->driver)) < 0)
+			return NULL;
+
+		entry->initialized = 1;
+	}
+
+    return entry->driver;
+}
+
+static git_merge_driver *merge_driver_lookup_with_default(const char *name)
+{
+	git_merge_driver *driver = git_merge_driver_lookup(name);
+
+	if (driver == NULL)
+		driver = git_merge_driver_lookup("*");
+
+	if (driver == NULL)
+		driver = &git_merge_driver__text;
+
+	return driver;
+}
+
+static int merge_driver_name_for_path(
+	const char **out,
+	git_repository *repo,
+	const char *path)
+{
+	const char *value;
+	int error;
+
+	*out = NULL;
+
+	if ((error = git_attr_get(&value, repo, 0, path, "merge")) < 0)
+		return error;
+
+	/* set: use the built-in 3-way merge driver ("text") */
+	if (GIT_ATTR_TRUE(value)) {
+		*out = merge_driver_name__text;
+		return 0;
+	}
+
+	/* unset: do not merge ("binary") */
+	if (GIT_ATTR_FALSE(value)) {
+		*out = merge_driver_name__binary;
+		return 0;
+	}
+
+	if (GIT_ATTR_UNSPECIFIED(value)) {
+		/* TODO */
+		/* if there's a merge.default configuration value, use it */
+		*out = merge_driver_name__text;
+		return 0;
+	}
+	
+	*out = value;
+	return 0;
+}
+
+int git_merge_driver_for_source(
+	git_merge_driver **driver_out,
+	void **data_out,
+	const git_merge_driver_source *src)
+{
+	const char *path, *driver_name;
+	git_merge_driver *driver;
+	void *data = NULL;
+	int error = 0;
+
+	path = git_merge_file__best_path(
+		src->ancestor ? src->ancestor->path : NULL,
+		src->ours ? src->ours->path : NULL,
+		src->theirs ? src->theirs->path : NULL);
+
+	if ((error = merge_driver_name_for_path(&driver_name, src->repo, path)) < 0)
+		return error;
+
+	driver = merge_driver_lookup_with_default(driver_name);
+
+	if (driver->check)
+		error = driver->check(driver, &data, driver_name, src);
+
+	if (error == GIT_PASSTHROUGH)
+		driver = &git_merge_driver__text;
+	else if (error == GIT_EMERGECONFLICT)
+		driver = &git_merge_driver__binary;
+	else
+		goto done;
+
+	error = 0;
+	data = NULL;
+
+	if (driver->check)
+		error = driver->check(driver, &data, driver_name, src);
+
+	/* the text and binary drivers must succeed their check */
+	assert(error == 0);
+
+done:
+	*driver_out = driver;
+	*data_out = data;
+	return error;
+}
+

--- a/src/merge_driver.c
+++ b/src/merge_driver.c
@@ -379,6 +379,12 @@ int git_merge_driver_for_source(
 
 	driver = merge_driver_lookup_with_wildcard(driver_name);
 
+        if (driver == NULL)
+        {
+            giterr_set(GITERR_MERGE, "The driver '%s' doesn't exist", driver_name);
+            return(GIT_ERROR);
+        }
+
 	if (driver && driver->check) {
 		error = driver->check(driver, &data, driver_name, src);
 

--- a/tests/merge/driver.c
+++ b/tests/merge/driver.c
@@ -1,0 +1,208 @@
+#include "clar_libgit2.h"
+#include "git2/repository.h"
+#include "git2/merge.h"
+#include "buffer.h"
+#include "merge.h"
+
+#define TEST_REPO_PATH "merge-resolve"
+#define BRANCH_ID "7cb63eed597130ba4abb87b3e544b85021905520"
+
+static git_repository *repo;
+static git_index *repo_index;
+
+static void test_drivers_register(void);
+static void test_drivers_unregister(void);
+
+void test_merge_driver__initialize(void)
+{
+    git_config *cfg;
+
+    repo = cl_git_sandbox_init(TEST_REPO_PATH);
+    git_repository_index(&repo_index, repo);
+
+    /* Ensure that the user's merge.conflictstyle doesn't interfere */
+    cl_git_pass(git_repository_config(&cfg, repo));
+
+    cl_git_pass(git_config_set_string(cfg, "merge.conflictstyle", "merge"));
+    cl_git_pass(git_config_set_bool(cfg, "core.autocrlf", false));
+
+	test_drivers_register();
+
+    git_config_free(cfg);
+}
+
+void test_merge_driver__cleanup(void)
+{
+	test_drivers_unregister();
+
+    git_index_free(repo_index);
+	cl_git_sandbox_cleanup();
+}
+
+struct test_merge_driver {
+	git_merge_driver base;
+	int initialized;
+	int shutdown;
+};
+
+static int test_driver_init(git_merge_driver *s)
+{
+	struct test_merge_driver *self = (struct test_merge_driver *)s;
+	self->initialized = 1;
+	return 0;
+}
+
+static void test_driver_shutdown(git_merge_driver *s)
+{
+	struct test_merge_driver *self = (struct test_merge_driver *)s;
+	self->shutdown = 1;
+}
+
+static int test_driver_check(
+	git_merge_driver *s,
+	void **payload,
+	const char *name,
+	const git_merge_driver_source *src)
+{
+	GIT_UNUSED(s);
+	GIT_UNUSED(src);
+
+	*payload = git__strdup(name);
+	GITERR_CHECK_ALLOC(*payload);
+
+	return 0;
+}
+
+static int test_driver_apply(
+	git_merge_driver *s,
+	void **payload,
+	const char **path_out,
+	uint32_t *mode_out,
+	git_buf *merged_out,
+	const git_merge_driver_source *src)
+{
+	GIT_UNUSED(s);
+	GIT_UNUSED(src);
+
+	*path_out = "applied.txt";
+	*mode_out = GIT_FILEMODE_BLOB;
+
+	return git_buf_printf(merged_out, "This is the `%s` driver.\n",
+		(char *)*payload);
+}
+
+static void test_driver_cleanup(git_merge_driver *s, void *payload)
+{
+	GIT_UNUSED(s);
+
+	git__free(payload);
+}
+
+
+static struct test_merge_driver test_driver_custom = {
+	{
+		GIT_MERGE_DRIVER_VERSION,
+		test_driver_init,
+		test_driver_shutdown,
+		test_driver_check,
+		test_driver_apply,
+		test_driver_cleanup
+	},
+	0,
+	0,
+};
+
+static struct test_merge_driver test_driver_wildcard = {
+	{
+		GIT_MERGE_DRIVER_VERSION,
+		test_driver_init,
+		test_driver_shutdown,
+		test_driver_check,
+		test_driver_apply,
+		test_driver_cleanup
+	},
+	0,
+	0,
+};
+
+static void test_drivers_register(void)
+{
+	cl_git_pass(git_merge_driver_register("custom", &test_driver_custom.base));
+	cl_git_pass(git_merge_driver_register("*", &test_driver_wildcard.base));
+}
+
+static void test_drivers_unregister(void)
+{
+	cl_git_pass(git_merge_driver_unregister("custom"));
+	cl_git_pass(git_merge_driver_unregister("*"));
+}
+
+static void set_gitattributes_to(const char *driver)
+{
+	git_buf line = GIT_BUF_INIT;
+
+	cl_git_pass(git_buf_printf(&line, "automergeable.txt merge=%s\n", driver));
+	cl_git_mkfile(TEST_REPO_PATH "/.gitattributes", line.ptr);
+	git_buf_free(&line);
+}
+
+static void merge_branch(void)
+{
+	git_oid their_id;
+	git_annotated_commit *their_head;
+
+	cl_git_pass(git_oid_fromstr(&their_id, BRANCH_ID));
+	cl_git_pass(git_annotated_commit_lookup(&their_head, repo, &their_id));
+
+	cl_git_pass(git_merge(repo, (const git_annotated_commit **)&their_head,
+		1, NULL, NULL));
+
+	git_annotated_commit_free(their_head);
+}
+
+void test_merge_driver__custom(void)
+{
+	const char *expected = "This is the `custom` driver.\n";
+	set_gitattributes_to("custom");
+	merge_branch();
+
+	cl_assert_equal_file(expected, strlen(expected),
+		TEST_REPO_PATH "/applied.txt");
+}
+
+void test_merge_driver__wildcard(void)
+{
+	const char *expected = "This is the `foobar` driver.\n";
+	set_gitattributes_to("foobar");
+	merge_branch();
+
+	cl_assert_equal_file(expected, strlen(expected),
+		TEST_REPO_PATH "/applied.txt");
+}
+
+void test_merge_driver__shutdown_is_called(void)
+{
+    test_driver_custom.initialized = 0;
+    test_driver_custom.shutdown = 0;
+    test_driver_wildcard.initialized = 0;
+    test_driver_wildcard.shutdown = 0;
+    
+    /* run the merge with the custom driver */
+    set_gitattributes_to("custom");
+    merge_branch();
+    
+	/* unregister the drivers, ensure their shutdown function is called */
+	test_drivers_unregister();
+
+    /* since the `custom` driver was used, it should have been initialized and
+     * shutdown, but the wildcard driver was not used at all and should not
+     * have been initialized or shutdown.
+     */
+	cl_assert(test_driver_custom.initialized);
+	cl_assert(test_driver_custom.shutdown);
+	cl_assert(!test_driver_wildcard.initialized);
+	cl_assert(!test_driver_wildcard.shutdown);
+
+	test_drivers_register();
+}
+

--- a/tests/merge/workdir/simple.c
+++ b/tests/merge/workdir/simple.c
@@ -330,6 +330,42 @@ void test_merge_workdir_simple__union(void)
 	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 4));
 }
 
+void test_merge_workdir_simple__gitattributes_union(void)
+{
+	git_buf conflicting_buf = GIT_BUF_INIT;
+
+	struct merge_index_entry merge_index_entries[] = {
+		ADDED_IN_MASTER_INDEX_ENTRY,
+		AUTOMERGEABLE_INDEX_ENTRY,
+		CHANGED_IN_BRANCH_INDEX_ENTRY,
+		CHANGED_IN_MASTER_INDEX_ENTRY,
+
+		{ 0100644, "72cdb057b340205164478565e91eb71647e66891", 0, "conflicting.txt" },
+
+		UNCHANGED_INDEX_ENTRY,
+	};
+
+	struct merge_reuc_entry merge_reuc_entries[] = {
+		AUTOMERGEABLE_REUC_ENTRY,
+		CONFLICTING_REUC_ENTRY,
+		REMOVED_IN_BRANCH_REUC_ENTRY,
+		REMOVED_IN_MASTER_REUC_ENTRY
+	};
+
+	set_core_autocrlf_to(repo, false);
+	cl_git_mkfile(TEST_REPO_PATH "/.gitattributes", "conflicting.txt merge=union\n");
+
+	merge_simple_branch(GIT_MERGE_FILE_FAVOR_NORMAL, 0);
+
+	cl_git_pass(git_futils_readbuffer(&conflicting_buf,
+		TEST_REPO_PATH "/conflicting.txt"));
+	cl_assert(strcmp(conflicting_buf.ptr, CONFLICTING_UNION_FILE) == 0);
+	git_buf_free(&conflicting_buf);
+
+	cl_assert(merge_test_index(repo_index, merge_index_entries, 6));
+	cl_assert(merge_test_reuc(repo_index, merge_reuc_entries, 4));
+}
+
 void test_merge_workdir_simple__diff3_from_config(void)
 {
 	git_config *config;


### PR DESCRIPTION
... when NULL was returned by that lookup_with_wildcard, and that crashed the SW, not too many lines of code later. Why it did not find the driver name, nor the \* wildcard - is probably due to my continuing misunderstanding of the merge_drivers - but this just feels more robust anyway.
